### PR TITLE
Fix PHP session conflict with SimpleSAML

### DIFF
--- a/plugins/Authentication/Saml/adSAML.php
+++ b/plugins/Authentication/Saml/adSAML.php
@@ -111,6 +111,7 @@ class adSAML
             $this->userAttributes = $this->authSimple->getAttributes();
             $returnValue = true;
         }
+        SimpleSAML_Session::getSessionFromRequest()->cleanup(); // Reverts to our PHP session
         return $returnValue;
     }
 


### PR DESCRIPTION
Following guidelines from the SimpleSAML documentation (https://simplesamlphp.org/docs/stable/simplesamlphp-sp-api#section_0_1), a cleanup is necessary after calling the SimpleSAML api to authenticate in order to use the correct php Session.
Without cleanup, the USER_SESSION is saved in the SimpleSAML Session and checks performed during the `Page.IsAuthenticated()` fail, looking in a different session and triggering a redirect loop