### PR TITLE
Add compatibility with PHP8 + minor bux fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,16 +1,48 @@
 {
-    // doc: https://code.visualstudio.com/docs/editor/debugging#_launchjson-attributes
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {
             "name": "Listen for Xdebug",
             "type": "php",
             "request": "launch",
-            "stopOnEntry": false,
-            "port": 9000, // Xdebug 3 default port
-            "skipFiles": [
-                "tpl_c/**"
-            ],
+            "port": 9003
         },
+        {
+            "name": "Launch currently open script",
+            "type": "php",
+            "request": "launch",
+            "program": "${file}",
+            "cwd": "${fileDirname}",
+            "port": 0,
+            "runtimeArgs": [
+                "-dxdebug.start_with_request=yes"
+            ],
+            "env": {
+                "XDEBUG_MODE": "debug,develop",
+                "XDEBUG_CONFIG": "client_port=${port}"
+            }
+        },
+        {
+            "name": "Launch Built-in web server",
+            "type": "php",
+            "request": "launch",
+            "runtimeArgs": [
+                "-dxdebug.mode=debug",
+                "-dxdebug.start_with_request=yes",
+                "-S",
+                "localhost:0"
+            ],
+            "program": "",
+            "cwd": "${workspaceRoot}",
+            "port": 9003,
+            "serverReadyAction": {
+                "pattern": "Development Server \\(http://localhost:([0-9]+)\\) started",
+                "uriFormat": "http://localhost:%s",
+                "action": "openExternally"
+            }
+        }
     ]
 }

--- a/Presenters/Install/Installer.php
+++ b/Presenters/Install/Installer.php
@@ -39,7 +39,7 @@ class Installer
 
         $create_user = new MySqlScript(ROOT_DIR . 'database_schema/create-user.sql');
         $create_user->Replace('librebooking', $database_name);
-        $create_user->Replace('schedule_user', $database_user);
+        $create_user->Replace('lb_user', $database_user);
         $create_user->Replace('localhost', $hostname);
         $create_user->Replace('password', $database_password);
 

--- a/composer.json
+++ b/composer.json
@@ -2,13 +2,13 @@
     "description": "LibreBooking",
     "autoload": {},
     "require-dev": {
-        "kint-php/kint": "^3.3",
-        "kint-php/kint-smarty": "^1.0",
         "squizlabs/php_codesniffer": "^3.6",
-        "phpcompatibility/php-compatibility": "^9.3"
+        "phpcompatibility/php-compatibility": "^9.3",
+        "kint-php/kint": "^4.1"
     },
     "require" : {
-        "php" : ">=7.3"
+        "php" : ">=8.0",
+        "smarty/smarty": "^4.2"
     },
     "scripts": {
         "install-tools":"phive install --trust-gpg-keys",

--- a/config/config.devel.php
+++ b/config/config.devel.php
@@ -1,5 +1,6 @@
 <?php
 
+mysqli_report(MYSQLI_REPORT_OFF);
 error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT);
 //ini_set('display_errors', 1);
 //ini_set('display_startup_errors', 1);

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -1,5 +1,6 @@
 <?php
 
+mysqli_report(MYSQLI_REPORT_OFF);
 error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT);
 //ini_set('display_errors', 1);
 //ini_set('display_startup_errors', 1);

--- a/database_schema/create-user.sql
+++ b/database_schema/create-user.sql
@@ -1,7 +1,7 @@
 DROP USER IF EXISTS 'lb_user'@'localhost';
-DROP USER IF EXISTS 'lb_user'@'127.0.0.1';
-
 CREATE USER 'lb_user'@'localhost' identified by 'password';
+
+DROP USER IF EXISTS 'lb_user'@'127.0.0.1';
 CREATE USER 'lb_user'@'127.0.0.1' identified by 'password';
 
 GRANT ALL on librebooking.* to 'lb_user'@'localhost';


### PR DESCRIPTION
Attempt to make the code work with PHP8.
Actually, I've tested the code with Ubuntu 22.04, PHP8.1, MySQL 8.0.30.

The changes are the following:

1. [.vscode/launch.json](.vscode/launch.json) - setup to match the XDebug 3 default configuration;
2. [config/config.devel.php](config/config.devel.php) and [config/config.dist.php](config/config.dist.php) - overwrite `mysqli` error reporting setting to the PHP7 default settings;
3. [composer.json](composer.json) - upgrade of the dependances version.

Moreover, some minor bug fixes are present.

1. [Presenters/Install/Installer.php](Presenters/Install/Installer.php) - fixed the db user name string to be replaced from [database_schema/create-user.sql](database_schema/create-user.sql) with the correct one;
2. [database_schema/create-user.sql](database_schema/create-user.sql) - reordering the SQL instruction to avoid possible duplicated user name creating (see details below).

About the [database_schema/create-user.sql](database_schema/create-user.sql), the file has been changed to avoid a possible attempt to creat duplicate user. In [Presenters/Install/Installer.php](Presenters/Install/Installer.php), the sql file is loaded and some strings are replaced. In particular, db host, user name and password. Let me consider a `config.php` where the db host is set to `127.0.0.1`.

After the replace, the sql file is (`localhost` is replaced with `127.0.0.1`)

```
DROP USER IF EXISTS 'lb_user'@'127.0.0.1';
DROP USER IF EXISTS 'lb_user'@'127.0.0.1';

CREATE USER 'lb_user'@'127.0.0.1' identified by 'password';
CREATE USER 'lb_user'@'127.0.0.1' identified by 'password';

GRANT ALL on librebooking.* to 'lb_user'@'127.0.0.1';
GRANT ALL on librebooking.* to 'lb_user'@'127.0.0.1';
```

Thus, a duplicated user error may be raised by mysql