### PR TITLE
Fix SQL user creation

### DIFF
--- a/database_schema/create-user.sql
+++ b/database_schema/create-user.sql
@@ -1,8 +1,8 @@
-DROP USER IF EXISTS 'lb_user'@'localhost';
-DROP USER IF EXISTS 'lb_user'@'127.0.0.1';
+DROP USER IF EXISTS 'schedule_user'@'localhost';
+DROP USER IF EXISTS 'schedule_user'@'127.0.0.1';
 
-CREATE USER 'lb_user'@'localhost' identified by 'password';
-CREATE USER 'lb_user'@'127.0.0.1' identified by 'password';
+CREATE USER 'schedule_user'@'localhost' identified by 'password';
+CREATE USER 'schedule_user'@'127.0.0.1' identified by 'password';
 
-GRANT ALL on librebooking.* to 'lb_user'@'localhost';
-GRANT ALL on librebooking.* to 'lb_user'@'127.0.0.1';
+GRANT ALL on librebooking.* to 'schedule_user'@'localhost';
+GRANT ALL on librebooking.* to 'schedule_user'@'127.0.0.1';

--- a/database_schema/create-user.sql
+++ b/database_schema/create-user.sql
@@ -1,8 +1,8 @@
-DROP USER IF EXISTS 'schedule_user'@'localhost';
+DROP USER IF EXISTS 'schedule_user'@'%';
 DROP USER IF EXISTS 'schedule_user'@'127.0.0.1';
 
-CREATE USER 'schedule_user'@'localhost' identified by 'password';
+CREATE USER 'schedule_user'@'%' identified by 'password';
 CREATE USER 'schedule_user'@'127.0.0.1' identified by 'password';
 
-GRANT ALL on librebooking.* to 'schedule_user'@'localhost';
+GRANT ALL on librebooking.* to 'schedule_user'@'%';
 GRANT ALL on librebooking.* to 'schedule_user'@'127.0.0.1';


### PR DESCRIPTION
### Changes

**SQL user name inconsistency**
There is an SQL user name inconsistency between the files:
- **Presenters/Install/Installer.php**: which uses schedule_user
- **database_schema/create-user.sql**: which uses lb_user

I chose to modify the file create-user.sql, but one could decide to modify the file Installer.php

**IP address incorrect when the database and web servers are not on the same host**
The Presenters/Install/Installer.php file will create 2 SQL users, with 2 different ip addresses:
- 127.0.0.1
- database ip address

This is incorrect when the database and web servers are on 2 different ip addresses (ex: when the database and web servers run on 2 separate containers).
One could fix the Installer.php file to use the web server ip address, but it is preferable to use the wildcard ip address "%", for it will continue to work in the case that the web server ip address changes.